### PR TITLE
SSUTO-86 TASK: Deprecate Eureka Service Discovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,15 @@
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
     </dependency>
 
   </dependencies>

--- a/src/main/java/com/ss/utopia/orchestrator/OrchestratorApplication.java
+++ b/src/main/java/com/ss/utopia/orchestrator/OrchestratorApplication.java
@@ -1,29 +1,12 @@
 package com.ss.utopia.orchestrator;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.commons.util.InetUtils;
-import org.springframework.cloud.netflix.eureka.EurekaInstanceConfigBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Profile;
 
 @SpringBootApplication
 public class OrchestratorApplication {
 
   public static void main(String[] args) {
     SpringApplication.run(OrchestratorApplication.class, args);
-  }
-
-  @Profile("ecs")
-  @Bean
-  public EurekaInstanceConfigBean eurekaInstanceConfigBean(InetUtils inetUtils)
-      throws UnknownHostException {
-    var config = new EurekaInstanceConfigBean(inetUtils);
-    config.setIpAddress(InetAddress.getLocalHost().getHostAddress());
-    config.setNonSecurePort(80);
-    config.setPreferIpAddress(true);
-    return config;
   }
 }

--- a/src/main/java/com/ss/utopia/orchestrator/config/LoadBalancedRoutesConfig.java
+++ b/src/main/java/com/ss/utopia/orchestrator/config/LoadBalancedRoutesConfig.java
@@ -1,53 +1,58 @@
 package com.ss.utopia.orchestrator.config;
 
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@Setter
+@Getter
 @Configuration
+@ConfigurationProperties(prefix = "com.ss.utopia.orchestrator.service-url", ignoreUnknownFields = false)
 public class LoadBalancedRoutesConfig {
 
-  public static final String API_LATEST = "/api/v0.1";
-
-  public static final String AUTH_SERVICE = "lb://utopia-auth-service";
-  public static final String FLIGHTS_SERVICE = "lb://utopia-flights-service";
-  public static final String CUSTOMERS_SERVICE = "lb://utopia-customers-service";
-  public static final String TICKETS_SERVICE = "lb://utopia-tickets-service";
+  private String version;
+  private String auth;
+  private String customers;
+  private String flights;
+  private String tickets;
 
   @Bean
   public RouteLocator routeLocator(RouteLocatorBuilder builder) {
     return builder.routes()
         .route(r -> r.path(GatewayConstants.AUTHENTICATE)
-            .uri(AUTH_SERVICE))
+            .uri(auth))
 
         .route(r -> r.path(GatewayConstants.ACCOUNTS + "/**")
-            .filters(f -> f.prefixPath(API_LATEST))
-            .uri(AUTH_SERVICE))
+            .filters(f -> f.prefixPath(version))
+            .uri(auth))
 
         .route(r -> r.path(GatewayConstants.AIRPLANES + "/**")
-            .filters(f -> f.prefixPath(API_LATEST))
-            .uri(FLIGHTS_SERVICE))
+            .filters(f -> f.prefixPath(version))
+            .uri(flights))
 
         .route(r -> r.path(GatewayConstants.AIRPORTS + "/**")
-            .filters(f -> f.prefixPath(API_LATEST))
-            .uri(FLIGHTS_SERVICE))
+            .filters(f -> f.prefixPath(version))
+            .uri(flights))
 
         .route(r -> r.path(GatewayConstants.CUSTOMERS, GatewayConstants.CUSTOMERS + "/**")
-            .filters(f -> f.prefixPath(API_LATEST))
-            .uri(CUSTOMERS_SERVICE))
+            .filters(f -> f.prefixPath(version))
+            .uri(customers))
 
         .route(r -> r.path(GatewayConstants.FLIGHTS + "/**")
-            .filters(f -> f.prefixPath(API_LATEST))
-            .uri(FLIGHTS_SERVICE))
+            .filters(f -> f.prefixPath(version))
+            .uri(flights))
 
         .route(r -> r.path(GatewayConstants.TICKETS + "/**")
-            .filters(f -> f.prefixPath(API_LATEST))
-            .uri(TICKETS_SERVICE))
+            .filters(f -> f.prefixPath(version))
+            .uri(tickets))
 
         .route(r -> r.path(GatewayConstants.SERVICING_AREA + "/**")
-            .filters(f -> f.prefixPath(API_LATEST))
-            .uri(FLIGHTS_SERVICE))
+            .filters(f -> f.prefixPath(version))
+            .uri(flights))
 
         .build();
   }

--- a/src/main/resources/application-ecs.properties
+++ b/src/main/resources/application-ecs.properties
@@ -1,1 +1,6 @@
 server.port=443
+com.ss.utopia.orchestrator.service-url.version=/api/v0.1
+com.ss.utopia.orchestrator.service-url.auth=http://utopia-auth-service:8089
+com.ss.utopia.orchestrator.service-url.customers=http://utopia-customers-service:8081
+com.ss.utopia.orchestrator.service-url.flights=http://utopia-flights-service:8083
+com.ss.utopia.orchestrator.service-url.tickets=http://utopia-tickets-service:8082

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,6 @@
+server.port=8080
+com.ss.utopia.orchestrator.service-url.version=/api/v0.1
+com.ss.utopia.orchestrator.service-url.auth=http://localhost:8089
+com.ss.utopia.orchestrator.service-url.customers=http://localhost:8081
+com.ss.utopia.orchestrator.service-url.flights=http://localhost:8083
+com.ss.utopia.orchestrator.service-url.tickets=http://localhost:8082

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,3 @@
 spring.application.name=utopia-orchestrator-service
 
-eureka.client.register-with-eureka=false
-eureka.client.fetch-registry=true
+spring.profiles.active=local


### PR DESCRIPTION
This change commits to using service discovery created by Docker Compose
for ECS deployments. For local development, no service discovery will be
necessary. Instead, we are providing an additional `local` profile for
direction to services running on localhost. The `ecs` profile has been
updated to use the docker service discovery urls. As such, the Eureka
dependency has been removed, and the `ecs` profile Bean for handling
Eureka has been removed.